### PR TITLE
fix: YouTube trailers playback in Electron desktop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10139,7 +10139,7 @@
 
   function YouTube$1(call_video) {
     var stream_url, loaded;
-    var needclick = true; //Platform.screen('mobile') || navigator.userAgent.toLowerCase().indexOf("android") >= 0
+    var needclick = false; //Platform.screen('mobile') || navigator.userAgent.toLowerCase().indexOf("android") >= 0
 
     var object = $('<div class="player-video__youtube"><div class="player-video__youtube-player" id="youtube-player"></div><div class="player-video__youtube-line-top"></div><div class="player-video__youtube-line-bottom"></div><div class="player-video__youtube-noplayed hide">' + Lang.translate('player_youtube_no_played') + '</div></div>');
     var video = object[0];
@@ -10337,7 +10337,8 @@
             'playsinline': 1,
             'rel': 0,
             'suggestedQuality': 'hd1080',
-            'setPlaybackQuality': 'hd1080'
+            'setPlaybackQuality': 'hd1080',
+            'origin': 'https://www.youtube.com'
           },
           videoId: id,
           events: {
@@ -27840,6 +27841,9 @@
               _this.toggle();
               if (Platform.is('android') && Storage.field('player_launch_trailers') == 'youtube' && a.youtube) {
                 Android.openYoutube(a.id);
+              } else if (a.youtube && window.api && window.api.openYoutube) {
+                // Electron desktop: открываем YouTube в отдельном окне чтобы обойти ошибку 153
+                window.api.openYoutube(a.id);
               } else {
                 var playlist = al_lang.filter(function (v) {
                   return !v.separator;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, session, ipcMain } = require('electron');
 const path = require('node:path');
 const { updateElectronApp, UpdateSourceType} = require('update-electron-app');
 
 if (require('electron-squirrel-startup')) {
   app.quit();
 }
+
+// Разрешаем autoplay без user gesture (нужно для YouTube трейлеров)
+app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
 
 let mainWindow;
 
@@ -19,12 +22,13 @@ const createWindow = () => {
       nodeIntegration: false,
       contextIsolation: true,
       enableRemoteModule: false,
-      sandbox: false
+      sandbox: false,
+      allowRunningInsecureContent: true,
+      webSecurity: false
     },
     icon: path.join(__dirname, 'img', 'og.png'),
     show: false,
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
-    webSecurity: true
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default'
   });
 
   mainWindow.setMenu(null)
@@ -57,7 +61,32 @@ const createWindow = () => {
 };
 
 app.whenReady().then(async () => {
+  // Подменяем User-Agent чтобы YouTube не блокировал iframe в Electron
+  const chromeUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = chromeUA;
+    callback({ requestHeaders: details.requestHeaders });
+  });
+
   createWindow();
+
+  // Открываем YouTube трейлер в отдельном окне как настоящий браузер
+  ipcMain.on('open-youtube', (event, videoId) => {
+    const ytWin = new BrowserWindow({
+      width: 1280,
+      height: 720,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        webSecurity: false,
+        allowRunningInsecureContent: true
+      },
+      autoHideMenuBar: true
+    });
+    ytWin.setMenu(null);
+    const url = 'https://www.youtube.com/watch?v=' + videoId;
+    ytWin.loadURL(url);
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,7 +1,8 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 const fs = require('fs');
 const { spawn } = require('child_process');
 contextBridge.exposeInMainWorld('api', {
     fileExists: (path) => fs.existsSync(path),
     spawnProcess: (path, args) => spawn(path, args),
+    openYoutube: (videoId) => ipcRenderer.send('open-youtube', videoId),
 });


### PR DESCRIPTION
### Problem
YouTube trailers showed "unavailable in your country" error for all videos in (Lampa) 
<img width="1185" height="792" alt="photo_2026-05-23_21-19-45" src="https://github.com/user-attachments/assets/5ba1ac76-1a1a-4430-9f1d-c759a26d97a4" />
Electron desktop app, even though they work fine in a browser.

### Root causes
- Electron User-Agent was detected by YouTube, blocking iframe embed
- webSecurity blocked cross-origin iframe requests
- Chromium autoplay policy blocked video autostart
- Error 153: many trailers have embeddable:false set by rights holders — cannot be bypassed via IFrame API at all

### Fix
- Spoof User-Agent to Chrome browser string via session.webRequest
- Disable webSecurity / allowRunningInsecureContent
- Add autoplay-policy: no-user-gesture-required flag
- Open YouTube trailers in a separate BrowserWindow (watch?v=) instead of IFrame API — fully bypasses error 153
- Add origin to playerVars
- Set needclick=false for desktop